### PR TITLE
Fix cache memory leak

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -22,6 +22,10 @@ class Cache {
       }
     }
 
+    if (isNaN(size) || size > this.MAX_CACHE_SIZE) {
+      return;
+    }
+
     while (this.size + size > this.MAX_CACHE_SIZE) {
       const url = this.fifo.shift();
       const entry = this.map.get(url);

--- a/cache.js
+++ b/cache.js
@@ -12,9 +12,16 @@ class Cache {
     let size;
     if (typeof data === 'string') {
       size = data.length * 2;
-    } else {
+    } else if (Buffer.isBuffer(data)) {
       size = data.length;
+    } else if ('data' in data) {
+      if (typeof data.data === 'string') {
+        size = data.data.length * 2;
+      } else if (Buffer.isBuffer(data.data)) {
+        size = data.data.length;
+      }
     }
+
     while (this.size + size > this.MAX_CACHE_SIZE) {
       const url = this.fifo.shift();
       const entry = this.map.get(url);

--- a/test/spec/loader.spec.js
+++ b/test/spec/loader.spec.js
@@ -13,7 +13,7 @@ function createLoader() {
       const cb = params.pop();
       const err = path === '/not-found' ? new Error('Not Found') : null;
       setImmediate(() => {
-        cb(err);
+        cb(err, 'file contents string');
       });
     }
   };


### PR DESCRIPTION
The cache append function expects its data argument to be either a string or otherwise have a length property. 
Unfortunately the values that are passed to the cache are objects with a data property, and not strings or buffers. This causes data.length to be undefined, and the while loop for removing elements from cache to never run. The cache ends up growing in size, and if run for long enough exhausts all available memory.

This pull request changes the append function to handle either strings or buffers, or object with a data property which is either a string or a buffer. If none of this is the case, or if the size of the new object is larger than the maximum cache size, the object is not added to the cache.